### PR TITLE
ENH: support for SampleData[Contigs]

### DIFF
--- a/q2_types_genomics/per_sample_data/__init__.py
+++ b/q2_types_genomics/per_sample_data/__init__.py
@@ -9,12 +9,15 @@
 import importlib
 
 from ._format import (
-    MAGSequencesDirFmt, MultiMAGManifestFormat
+    MAGSequencesDirFmt, MultiMAGManifestFormat, ContigSequencesDirFmt
 )
-from._type import (
-    MAGs
+from ._type import (
+    MAGs, Contigs
 )
 
-__all__ = ['MAGs', 'MAGSequencesDirFmt', 'MultiMAGManifestFormat']
+__all__ = [
+    'MAGs', 'MAGSequencesDirFmt', 'MultiMAGManifestFormat',
+    'ContigSequencesDirFmt', 'Contigs'
+]
 
 importlib.import_module('q2_types_genomics.per_sample_data._transformer')

--- a/q2_types_genomics/per_sample_data/_format.py
+++ b/q2_types_genomics/per_sample_data/_format.py
@@ -112,4 +112,12 @@ class MAGSequencesDirFmt(MultiFASTADirectoryFormat):
     manifest = model.File('MANIFEST', format=MultiMAGManifestFormat)
 
 
-plugin.register_formats(MultiFASTADirectoryFormat, MAGSequencesDirFmt)
+ContigSequencesDirFmt = model.SingleFileDirectoryFormat(
+    'ContigSequencesDirFmt', 'contigs.fasta', DNAFASTAFormat
+)
+
+plugin.register_formats(
+    MultiFASTADirectoryFormat,
+    MAGSequencesDirFmt,
+    ContigSequencesDirFmt
+)

--- a/q2_types_genomics/per_sample_data/_type.py
+++ b/q2_types_genomics/per_sample_data/_type.py
@@ -9,14 +9,19 @@
 from q2_types.sample_data import SampleData
 from qiime2.core.type import SemanticType
 
-from . import MAGSequencesDirFmt
+from . import MAGSequencesDirFmt, ContigSequencesDirFmt
 from ..plugin_setup import plugin
 
 MAGs = SemanticType('MAGs', variant_of=SampleData.field['type'])
+Contigs = SemanticType('Contigs', variant_of=SampleData.field['type'])
 
-plugin.register_semantic_types(MAGs)
+plugin.register_semantic_types(MAGs, Contigs)
 
 plugin.register_semantic_type_to_format(
     SampleData[MAGs],
     artifact_format=MAGSequencesDirFmt
+)
+plugin.register_semantic_type_to_format(
+    SampleData[Contigs],
+    artifact_format=ContigSequencesDirFmt
 )

--- a/q2_types_genomics/per_sample_data/tests/__init__.py
+++ b/q2_types_genomics/per_sample_data/tests/__init__.py
@@ -1,3 +1,4 @@
+# ----------------------------------------------------------------------------
 # Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.

--- a/q2_types_genomics/per_sample_data/tests/test_format.py
+++ b/q2_types_genomics/per_sample_data/tests/test_format.py
@@ -7,14 +7,16 @@
 # ----------------------------------------------------------------------------
 
 import os
+import shutil
 import string
 import unittest
 
 from qiime2.core.exceptions import ValidationError
 from qiime2.plugin.testing import TestPluginBase
 
-from q2_types_genomics.per_sample_data._format import \
-    (MultiFASTADirectoryFormat, MultiMAGManifestFormat)
+from q2_types_genomics.per_sample_data._format import (
+    MultiFASTADirectoryFormat, MultiMAGManifestFormat, ContigSequencesDirFmt
+)
 
 
 class TestMultiMAGManifestFormat(TestPluginBase):
@@ -90,6 +92,12 @@ class TestFormats(TestPluginBase):
         with self.assertRaisesRegex(
                 ValidationError, 'should be .* per-sample directories'):
             format.validate()
+
+    def test_contig_seqs_dirfmt(self):
+        filepath = self.get_data_path('mags/mags-fasta/sample2/mag1.fasta')
+        shutil.copy(filepath, os.path.join(
+            self.temp_dir.name, 'contigs.fasta'))
+        ContigSequencesDirFmt(self.temp_dir.name, mode='r').validate()
 
 
 if __name__ == '__main__':

--- a/q2_types_genomics/per_sample_data/tests/test_type.py
+++ b/q2_types_genomics/per_sample_data/tests/test_type.py
@@ -11,7 +11,9 @@ import unittest
 from q2_types.sample_data import SampleData
 from qiime2.plugin.testing import TestPluginBase
 
-from q2_types_genomics.per_sample_data import MAGs, MAGSequencesDirFmt
+from q2_types_genomics.per_sample_data import (
+    MAGs, MAGSequencesDirFmt, Contigs, ContigSequencesDirFmt
+)
 
 
 class TestTypes(TestPluginBase):
@@ -20,10 +22,19 @@ class TestTypes(TestPluginBase):
     def test_mags_semantic_type_registration(self):
         self.assertRegisteredSemanticType(MAGs)
 
-    def test_sequences_semantic_type_to_format_registration(self):
+    def test_mags_semantic_type_to_format_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
             SampleData[MAGs],
             MAGSequencesDirFmt
+        )
+
+    def test_contigs_semantic_type_registration(self):
+        self.assertRegisteredSemanticType(Contigs)
+
+    def test_contigs_semantic_type_to_format_registration(self):
+        self.assertSemanticTypeRegisteredToFormat(
+            SampleData[Contigs],
+            ContigSequencesDirFmt
         )
 
 


### PR DESCRIPTION
Introduces formats and types required to work with contig FASTA files per sample:
- added `ContigSequencesDirFmt` format
- added `SampleData[Contigs]` type
- added tests

Closes #1 .