### PR TITLE
ENH: support for GenomeData[Loci]

### DIFF
--- a/q2_types_genomics/genome_data/__init__.py
+++ b/q2_types_genomics/genome_data/__init__.py
@@ -9,15 +9,18 @@
 import importlib
 
 from ._format import (
-    GenesDirectoryFormat, ProteinsDirectoryFormat, LociDirectoryFormat
+    GenesDirectoryFormat, ProteinsDirectoryFormat,
+    GFF3Format, LociDirectoryFormat
 )
+from ._transformer import IntervalMetadataIterator
 from ._type import (
     GenomeData, Genes, Proteins, Loci
 )
 
 __all__ = [
-    'GenomeData', 'Genes', 'Proteins', 'Loci',
-    'GenesDirectoryFormat', 'ProteinsDirectoryFormat', 'LociDirectoryFormat'
+    'GenomeData', 'Genes', 'Proteins', 'Loci', 'GFF3Format',
+    'GenesDirectoryFormat', 'ProteinsDirectoryFormat', 'LociDirectoryFormat',
+    'IntervalMetadataIterator'
 ]
 
 importlib.import_module('q2_types_genomics.genome_data._transformer')

--- a/q2_types_genomics/genome_data/__init__.py
+++ b/q2_types_genomics/genome_data/__init__.py
@@ -8,12 +8,16 @@
 
 import importlib
 
-from ._format import GenesDirectoryFormat, ProteinsDirectoryFormat
-from ._type import GenomeData, Genes, Proteins
+from ._format import (
+    GenesDirectoryFormat, ProteinsDirectoryFormat, LociDirectoryFormat
+)
+from ._type import (
+    GenomeData, Genes, Proteins, Loci
+)
 
 __all__ = [
-    'GenomeData', 'Genes', 'Proteins',
-    'GenesDirectoryFormat', 'ProteinsDirectoryFormat'
+    'GenomeData', 'Genes', 'Proteins', 'Loci',
+    'GenesDirectoryFormat', 'ProteinsDirectoryFormat', 'LociDirectoryFormat'
 ]
 
 importlib.import_module('q2_types_genomics.genome_data._transformer')

--- a/q2_types_genomics/genome_data/_format.py
+++ b/q2_types_genomics/genome_data/_format.py
@@ -6,8 +6,9 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from q2_types.feature_data import DNAFASTAFormat, ProteinFASTAFormat
 import qiime2.plugin.model as model
+from q2_types.feature_data import DNAFASTAFormat, ProteinFASTAFormat
+from qiime2.core.exceptions import ValidationError
 
 from ..plugin_setup import plugin
 
@@ -30,4 +31,129 @@ class ProteinsDirectoryFormat(model.DirectoryFormat):
         return '%s_proteins.fasta' % genome_id
 
 
-plugin.register_formats(GenesDirectoryFormat, ProteinsDirectoryFormat)
+
+class GFF3Format(model.TextFileFormat):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.directives = {}
+        self.directives_unofficial = {}
+
+    def _update_directives(self, line, line_number):
+        directive = line[2:].split(maxsplit=1)
+        if len(directive) <= 1:
+            raise ValidationError(
+                f'GFF directive entry on line {line_number} is incomplete.'
+            )
+        elif line.startswith('##'):
+            self.directives.update({directive[0]: directive[1]})
+        elif line.startswith('#!'):
+            self.directives_unofficial.update({directive[0]: directive[1]})
+
+    def _validate_directives(self) -> bool:
+        if 'gff-version' not in self.directives.keys():
+            raise ValidationError(
+                '"gff-version" directive is missing from the file headers.'
+            )
+        if not self.directives['gff-version'].startswith('3'):
+            raise ValidationError(
+                f'Invalid GFF format version: '
+                f'{self.directives["gff-version"]}. Only version 3 '
+                f'is supported.'
+            )
+        return True
+
+    @staticmethod
+    def _validate_feature_line(line, line_number):
+        line_elements = line.split('\t')
+        line_len = len(line_elements)
+        if line_len != 9:
+            raise ValidationError(
+                f'The entry on line {line_number} '
+                f'has an incorrect number of elements. All '
+                f'entries need to have 9 elements in a valid '
+                f'GFF3 file.'
+            )
+
+        # 1: seqid, 2: source, 3: type, 4: start, 5:stop,
+        # 6: score, 7:strand, 8:phase, 9:attributes
+        if any([True for x in line_elements
+                if x in {"", " "}]):
+            raise ValidationError(
+                f'An empty feature found on line '
+                f'{line_number}. Empty features should be '
+                f'denoted with a ".".'
+            )
+
+        if str(line_elements[0]).startswith('>'):
+            raise ValidationError(
+                'Landmark IDs must not start with an unescaped'
+                f' ">". The ID on line {line_number} was '
+                f'"{line_elements[0]}".'
+            )
+
+        if int(line_elements[3]) > int(line_elements[4]):
+            raise ValidationError(
+                f'Start position on line {line_number} '
+                f'is bigger than stop position.'
+            )
+
+        if any([int(line_elements[3]) <= 0,
+                int(line_elements[4]) <= 0]):
+            raise ValidationError(
+                'Coordinates should be expressed as '
+                f'positive,  1-based integers. At least '
+                f'one of the positions on line {line_number} '
+                f'is incorrect.'
+            )
+
+        if str(line_elements[6]) not in ['+', '-', '?', '.']:
+            raise ValidationError(
+                f'Strand of the feature on line {line_number} '
+                f'is not one of the allowed symbols (+-.?).'
+            )
+
+        if str(line_elements[2]) == 'CDS' and \
+                str(line_elements[7]) not in ['0', '1', '2']:
+            raise ValidationError(
+                'Features of type CDS require the phase to '
+                'be one of: 0, 1, 3. The phase on line '
+                f'{line_number} was {line_elements[7]}.'
+            )
+
+    def _validate_(self, level):
+        level_map = {'min': 100, 'max': float('inf')}
+        max_lines = level_map[level]
+
+        directives_validated = False
+
+        with self.path.open('rb') as fh:
+            try:
+                for line_number, line in enumerate(fh, 1):
+                    line = line.strip()
+                    if line_number >= max_lines:
+                        return
+                    line = line.decode('utf-8-sig')
+
+                    if line.startswith(("##", "#!")):
+                        self._update_directives(line, line_number)
+                    elif line.startswith('#'):
+                        continue
+                    else:
+                        if not directives_validated:
+                            directives_validated = self._validate_directives()
+                        self._validate_feature_line(line, line_number)
+
+            except UnicodeDecodeError as e:
+                raise ValidationError(f'utf-8 cannot decode byte on line '
+                                      f'{line_number}') from e
+
+
+LociDirectoryFormat = model.SingleFileDirectoryFormat(
+    'LociDirectoryFormat',
+    r'loci[0-9]+\.gff$',
+    GFF3Format
+)
+
+plugin.register_formats(
+    GenesDirectoryFormat, ProteinsDirectoryFormat, LociDirectoryFormat
+)

--- a/q2_types_genomics/genome_data/_format.py
+++ b/q2_types_genomics/genome_data/_format.py
@@ -31,8 +31,13 @@ class ProteinsDirectoryFormat(model.DirectoryFormat):
         return '%s_proteins.fasta' % genome_id
 
 
-
 class GFF3Format(model.TextFileFormat):
+    """
+    Generic Feature Format Version 3 (GFF3) spec:
+    https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md
+    NCBI modifications to the above:
+    https://www.ncbi.nlm.nih.gov/datasets/docs/reference-docs/file-formats/about-ncbi-gff3/
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.directives = {}

--- a/q2_types_genomics/genome_data/_format.py
+++ b/q2_types_genomics/genome_data/_format.py
@@ -38,6 +38,7 @@ class GFF3Format(model.TextFileFormat):
     NCBI modifications to the above:
     https://www.ncbi.nlm.nih.gov/datasets/docs/reference-docs/file-formats/about-ncbi-gff3/
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.directives = {}
@@ -153,11 +154,14 @@ class GFF3Format(model.TextFileFormat):
                                       f'{line_number}') from e
 
 
-LociDirectoryFormat = model.SingleFileDirectoryFormat(
-    'LociDirectoryFormat',
-    r'loci[0-9]+\.gff$',
-    GFF3Format
-)
+class LociDirectoryFormat(model.DirectoryFormat):
+    loci = model.FileCollection(r'loci[0-9]+\.gff$',
+                                format=GFF3Format)
+
+    @loci.set_path_maker
+    def loci_path_maker(self, genome_id):
+        return '%s_loci.gff' % genome_id
+
 
 plugin.register_formats(
     GenesDirectoryFormat, ProteinsDirectoryFormat, LociDirectoryFormat

--- a/q2_types_genomics/genome_data/_transformer.py
+++ b/q2_types_genomics/genome_data/_transformer.py
@@ -6,17 +6,17 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import collections.abc
 import os
 
 import pandas as pd
 import skbio
+from skbio.io import read
 
-from q2_types_genomics.genome_data import (
-    GenesDirectoryFormat, ProteinsDirectoryFormat
+from . import (
+    GenesDirectoryFormat, ProteinsDirectoryFormat, GFF3Format
 )
-
-from q2_types_genomics.plugin_setup import plugin
-
+from ..plugin_setup import plugin
 
 CONSTRUCTORS = {
     'DNA': skbio.DNA,
@@ -26,7 +26,7 @@ CONSTRUCTORS = {
 
 
 def _series_to_fasta(series, ff, seq_type='DNA'):
-    fp = str(f"{ff.path}/{series.name}.fasta")
+    fp = os.path.join(ff.path, f'{series.name}.fasta')
     with open(fp, 'w') as fh:
         for id_, seq in series.iteritems():
             if seq:
@@ -67,3 +67,26 @@ def _4(df: pd.DataFrame) -> ProteinsDirectoryFormat:
     result = ProteinsDirectoryFormat()
     df.apply(_series_to_fasta, axis=1, ff=result, seq_type='protein')
     return result
+
+
+class IntervalMetadataIterator(collections.abc.Iterable):
+    def __init__(self, generator):
+        self.generator = generator
+
+    def __iter__(self):
+        yield from self.generator
+
+
+@plugin.register_transformer
+def _5(fmt: GFF3Format) -> IntervalMetadataIterator:
+    generator = read(str(fmt), format='gff3')
+    return IntervalMetadataIterator(generator)
+
+
+@plugin.register_transformer
+def _7(data: IntervalMetadataIterator) -> GFF3Format:
+    ff = GFF3Format()
+    with ff.open() as fh:
+        for _id, im in data:
+            im.write(fh, format='gff3', seq_id=_id)
+    return ff

--- a/q2_types_genomics/genome_data/_type.py
+++ b/q2_types_genomics/genome_data/_type.py
@@ -9,14 +9,17 @@
 from qiime2.plugin import SemanticType
 
 from ..plugin_setup import plugin
-from . import GenesDirectoryFormat, ProteinsDirectoryFormat
+from . import (
+    GenesDirectoryFormat, ProteinsDirectoryFormat, LociDirectoryFormat
+)
 
 
 GenomeData = SemanticType('GenomeData', field_names='type')
 Genes = SemanticType('Genes', variant_of=GenomeData.field['type'])
 Proteins = SemanticType('Proteins', variant_of=GenomeData.field['type'])
+Loci = SemanticType('Loci', variant_of=GenomeData.field['type'])
 
-plugin.register_semantic_types(GenomeData, Genes, Proteins)
+plugin.register_semantic_types(GenomeData, Genes, Proteins, Loci)
 
 plugin.register_semantic_type_to_format(
     GenomeData[Genes],
@@ -26,4 +29,9 @@ plugin.register_semantic_type_to_format(
 plugin.register_semantic_type_to_format(
     GenomeData[Proteins],
     artifact_format=ProteinsDirectoryFormat
+)
+
+plugin.register_semantic_type_to_format(
+    GenomeData[Loci],
+    artifact_format=LociDirectoryFormat
 )

--- a/q2_types_genomics/genome_data/_type.py
+++ b/q2_types_genomics/genome_data/_type.py
@@ -8,11 +8,10 @@
 
 from qiime2.plugin import SemanticType
 
-from ..plugin_setup import plugin
 from . import (
     GenesDirectoryFormat, ProteinsDirectoryFormat, LociDirectoryFormat
 )
-
+from ..plugin_setup import plugin
 
 GenomeData = SemanticType('GenomeData', field_names='type')
 Genes = SemanticType('Genes', variant_of=GenomeData.field['type'])

--- a/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-corrupt.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-corrupt.gff
@@ -1,0 +1,2 @@
+>This data is corrupt
+ееееееееее

--- a/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-directive-empty.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-directive-empty.gff
@@ -1,0 +1,10 @@
+##
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ASM19595v2
+#!genome-build-accession NCBI_Assembly:GCA_000195955.2
+##sequence-region AL123456.3 1 4411532
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=83332
+AL123456.3	EMBL	region	1	4411532	.	+	.	ID=AL123456.3:1..4411532;Dbxref=taxon:83332;gbkey=Src;mol_type=genomic DNA;strain=H37Rv;type-material=type strain of Mycobacterium tuberculosis
+AL123456.3	EMBL	gene	1	1524	.	+	.	ID=gene-Rv0001;Name=dnaA;gbkey=Gene;gene=dnaA;gene_biotype=protein_coding;locus_tag=Rv0001
+AL123456.3	EMBL	CDS	1	1524	.	+	0	ID=cds-CCP42723.1;Parent=gene-Rv0001;Dbxref=EnsemblGenomes-Gn:Rv0001,EnsemblGenomes-Tr:CCP42723,GOA:P9WNW3,InterPro:IPR001957,InterPro:IPR003593,InterPro:IPR010921,InterPro:IPR013159,InterPro:IPR013317,InterPro:IPR018312,InterPro:IPR020591,InterPro:IPR027417,NCBI_GP:CCP42723.1;Name=CCP42723.1;Note=Rv0001%2C (MT0001%2C MTV029.01%2C P49993)%2C len: 507 aa. dnaA%2C chromosomal replication initiator protein (see citations below)%2C equivalent to other Mycobacterial chromosomal replication initiator proteins. Also highly similar to others except in N-terminus e.g. Q9ZH75|DNAA_STRCH chromosomal replication initiator protein from Streptomyces chrysomallus (624 aa). Contains PS00017 ATP/GTP-binding site motif A (P-loop) and PS01008 DnaA protein signature. Belongs to the DnaA family. Note that the first base of this gene has been taken as base 1 of the Mycobacterium tuberculosis H37Rv genomic sequence.;experiment=EXISTENCE: identified in proteomics study;gbkey=CDS;gene=dnaA;inference=protein motif:PROSITE:PS01008;locus_tag=Rv0001;product=Chromosomal replication initiator protein DnaA;protein_id=CCP42723.1;transl_table=11

--- a/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-empty-feature.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-empty-feature.gff
@@ -1,0 +1,10 @@
+##gff-version 3
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ASM19595v2
+#!genome-build-accession NCBI_Assembly:GCA_000195955.2
+##sequence-region AL123456.3 1 4411532
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=83332
+AL123456.3	EMBL	region	1	4411532	.	+	.	ID=AL123456.3:1..4411532;Dbxref=taxon:83332;gbkey=Src;mol_type=genomic DNA;strain=H37Rv;type-material=type strain of Mycobacterium tuberculosis
+AL123456.3	EMBL	gene	1	1524	.	+		ID=gene-Rv0001;Name=dnaA;gbkey=Gene;gene=dnaA;gene_biotype=protein_coding;locus_tag=Rv0001
+AL123456.3	EMBL	CDS	1	1524	.	+	0	ID=cds-CCP42723.1;Parent=gene-Rv0001;Dbxref=EnsemblGenomes-Gn:Rv0001,EnsemblGenomes-Tr:CCP42723,GOA:P9WNW3,InterPro:IPR001957,InterPro:IPR003593,InterPro:IPR010921,InterPro:IPR013159,InterPro:IPR013317,InterPro:IPR018312,InterPro:IPR020591,InterPro:IPR027417,NCBI_GP:CCP42723.1;Name=CCP42723.1;Note=Rv0001%2C (MT0001%2C MTV029.01%2C P49993)%2C len: 507 aa. dnaA%2C chromosomal replication initiator protein (see citations below)%2C equivalent to other Mycobacterial chromosomal replication initiator proteins. Also highly similar to others except in N-terminus e.g. Q9ZH75|DNAA_STRCH chromosomal replication initiator protein from Streptomyces chrysomallus (624 aa). Contains PS00017 ATP/GTP-binding site motif A (P-loop) and PS01008 DnaA protein signature. Belongs to the DnaA family. Note that the first base of this gene has been taken as base 1 of the Mycobacterium tuberculosis H37Rv genomic sequence.;experiment=EXISTENCE: identified in proteomics study;gbkey=CDS;gene=dnaA;inference=protein motif:PROSITE:PS01008;locus_tag=Rv0001;product=Chromosomal replication initiator protein DnaA;protein_id=CCP42723.1;transl_table=11

--- a/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-invalid-char.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-invalid-char.gff
@@ -1,0 +1,10 @@
+##gff-version 3
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ASM19595v2
+#!genome-build-accession NCBI_Assembly:GCA_000195955.2
+##sequence-region AL123456.3 1 4411532
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=83332
+AL123456.3	EMBL	region	1	4411532	.	+	.	ID=AL123456.3:1..4411532;Dbxref=taxon:83332;gbkey=Src;mol_type=genomic DNA;strain=H37Rv;type-material=type strain of Mycobacterium tuberculosis
+AL123456.3	EMBL	gene	1	1524	.	+	.	ID=gene-Rv0001;Name=dnaA;gbkey=Gene;gene=dnaA;gene_biotype=protein_coding;locus_tag=Rv0001
+>AL123456.3	EMBL	CDS	1	1524	.	+	0	ID=cds-CCP42723.1;Parent=gene-Rv0001;Dbxref=EnsemblGenomes-Gn:Rv0001,EnsemblGenomes-Tr:CCP42723,GOA:P9WNW3,InterPro:IPR001957,InterPro:IPR003593,InterPro:IPR010921,InterPro:IPR013159,InterPro:IPR013317,InterPro:IPR018312,InterPro:IPR020591,InterPro:IPR027417,NCBI_GP:CCP42723.1;Name=CCP42723.1;Note=Rv0001%2C (MT0001%2C MTV029.01%2C P49993)%2C len: 507 aa. dnaA%2C chromosomal replication initiator protein (see citations below)%2C equivalent to other Mycobacterial chromosomal replication initiator proteins. Also highly similar to others except in N-terminus e.g. Q9ZH75|DNAA_STRCH chromosomal replication initiator protein from Streptomyces chrysomallus (624 aa). Contains PS00017 ATP/GTP-binding site motif A (P-loop) and PS01008 DnaA protein signature. Belongs to the DnaA family. Note that the first base of this gene has been taken as base 1 of the Mycobacterium tuberculosis H37Rv genomic sequence.;experiment=EXISTENCE: identified in proteomics study;gbkey=CDS;gene=dnaA;inference=protein motif:PROSITE:PS01008;locus_tag=Rv0001;product=Chromosomal replication initiator protein DnaA;protein_id=CCP42723.1;transl_table=11

--- a/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-invalid-phase.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-invalid-phase.gff
@@ -1,0 +1,10 @@
+##gff-version 3
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ASM19595v2
+#!genome-build-accession NCBI_Assembly:GCA_000195955.2
+##sequence-region AL123456.3 1 4411532
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=83332
+AL123456.3	EMBL	region	1	4411532	.	+	.	ID=AL123456.3:1..4411532;Dbxref=taxon:83332;gbkey=Src;mol_type=genomic DNA;strain=H37Rv;type-material=type strain of Mycobacterium tuberculosis
+AL123456.3	EMBL	gene	1	1524	.	+	.	ID=gene-Rv0001;Name=dnaA;gbkey=Gene;gene=dnaA;gene_biotype=protein_coding;locus_tag=Rv0001
+AL123456.3	EMBL	CDS	1	1524	.	+	8	ID=cds-CCP42723.1;Parent=gene-Rv0001;Dbxref=EnsemblGenomes-Gn:Rv0001,EnsemblGenomes-Tr:CCP42723,GOA:P9WNW3,InterPro:IPR001957,InterPro:IPR003593,InterPro:IPR010921,InterPro:IPR013159,InterPro:IPR013317,InterPro:IPR018312,InterPro:IPR020591,InterPro:IPR027417,NCBI_GP:CCP42723.1;Name=CCP42723.1;Note=Rv0001%2C (MT0001%2C MTV029.01%2C P49993)%2C len: 507 aa. dnaA%2C chromosomal replication initiator protein (see citations below)%2C equivalent to other Mycobacterial chromosomal replication initiator proteins. Also highly similar to others except in N-terminus e.g. Q9ZH75|DNAA_STRCH chromosomal replication initiator protein from Streptomyces chrysomallus (624 aa). Contains PS00017 ATP/GTP-binding site motif A (P-loop) and PS01008 DnaA protein signature. Belongs to the DnaA family. Note that the first base of this gene has been taken as base 1 of the Mycobacterium tuberculosis H37Rv genomic sequence.;experiment=EXISTENCE: identified in proteomics study;gbkey=CDS;gene=dnaA;inference=protein motif:PROSITE:PS01008;locus_tag=Rv0001;product=Chromosomal replication initiator protein DnaA;protein_id=CCP42723.1;transl_table=11

--- a/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-invalid-start.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-invalid-start.gff
@@ -1,0 +1,10 @@
+##gff-version 3
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ASM19595v2
+#!genome-build-accession NCBI_Assembly:GCA_000195955.2
+##sequence-region AL123456.3 1 4411532
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=83332
+AL123456.3	EMBL	region	1	4411532	.	+	.	ID=AL123456.3:1..4411532;Dbxref=taxon:83332;gbkey=Src;mol_type=genomic DNA;strain=H37Rv;type-material=type strain of Mycobacterium tuberculosis
+AL123456.3	EMBL	gene	1528	1524	.	+	.	ID=gene-Rv0001;Name=dnaA;gbkey=Gene;gene=dnaA;gene_biotype=protein_coding;locus_tag=Rv0001
+AL123456.3	EMBL	CDS	1	1524	.	+	0	ID=cds-CCP42723.1;Parent=gene-Rv0001;Dbxref=EnsemblGenomes-Gn:Rv0001,EnsemblGenomes-Tr:CCP42723,GOA:P9WNW3,InterPro:IPR001957,InterPro:IPR003593,InterPro:IPR010921,InterPro:IPR013159,InterPro:IPR013317,InterPro:IPR018312,InterPro:IPR020591,InterPro:IPR027417,NCBI_GP:CCP42723.1;Name=CCP42723.1;Note=Rv0001%2C (MT0001%2C MTV029.01%2C P49993)%2C len: 507 aa. dnaA%2C chromosomal replication initiator protein (see citations below)%2C equivalent to other Mycobacterial chromosomal replication initiator proteins. Also highly similar to others except in N-terminus e.g. Q9ZH75|DNAA_STRCH chromosomal replication initiator protein from Streptomyces chrysomallus (624 aa). Contains PS00017 ATP/GTP-binding site motif A (P-loop) and PS01008 DnaA protein signature. Belongs to the DnaA family. Note that the first base of this gene has been taken as base 1 of the Mycobacterium tuberculosis H37Rv genomic sequence.;experiment=EXISTENCE: identified in proteomics study;gbkey=CDS;gene=dnaA;inference=protein motif:PROSITE:PS01008;locus_tag=Rv0001;product=Chromosomal replication initiator protein DnaA;protein_id=CCP42723.1;transl_table=11

--- a/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-invalid-strand.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-invalid-strand.gff
@@ -1,0 +1,10 @@
+##gff-version 3
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ASM19595v2
+#!genome-build-accession NCBI_Assembly:GCA_000195955.2
+##sequence-region AL123456.3 1 4411532
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=83332
+AL123456.3	EMBL	region	1	4411532	.	+	.	ID=AL123456.3:1..4411532;Dbxref=taxon:83332;gbkey=Src;mol_type=genomic DNA;strain=H37Rv;type-material=type strain of Mycobacterium tuberculosis
+AL123456.3	EMBL	gene	1	1524	.	+	.	ID=gene-Rv0001;Name=dnaA;gbkey=Gene;gene=dnaA;gene_biotype=protein_coding;locus_tag=Rv0001
+AL123456.3	EMBL	CDS	1	1524	.	$	0	ID=cds-CCP42723.1;Parent=gene-Rv0001;Dbxref=EnsemblGenomes-Gn:Rv0001,EnsemblGenomes-Tr:CCP42723,GOA:P9WNW3,InterPro:IPR001957,InterPro:IPR003593,InterPro:IPR010921,InterPro:IPR013159,InterPro:IPR013317,InterPro:IPR018312,InterPro:IPR020591,InterPro:IPR027417,NCBI_GP:CCP42723.1;Name=CCP42723.1;Note=Rv0001%2C (MT0001%2C MTV029.01%2C P49993)%2C len: 507 aa. dnaA%2C chromosomal replication initiator protein (see citations below)%2C equivalent to other Mycobacterial chromosomal replication initiator proteins. Also highly similar to others except in N-terminus e.g. Q9ZH75|DNAA_STRCH chromosomal replication initiator protein from Streptomyces chrysomallus (624 aa). Contains PS00017 ATP/GTP-binding site motif A (P-loop) and PS01008 DnaA protein signature. Belongs to the DnaA family. Note that the first base of this gene has been taken as base 1 of the Mycobacterium tuberculosis H37Rv genomic sequence.;experiment=EXISTENCE: identified in proteomics study;gbkey=CDS;gene=dnaA;inference=protein motif:PROSITE:PS01008;locus_tag=Rv0001;product=Chromosomal replication initiator protein DnaA;protein_id=CCP42723.1;transl_table=11

--- a/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-lines-unequal.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-lines-unequal.gff
@@ -1,0 +1,10 @@
+##gff-version 3
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ASM19595v2
+#!genome-build-accession NCBI_Assembly:GCA_000195955.2
+##sequence-region AL123456.3 1 4411532
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=83332
+AL123456.3	EMBL	region	1	4411532	.	+	.	ID=AL123456.3:1..4411532;Dbxref=taxon:83332;gbkey=Src;mol_type=genomic DNA;strain=H37Rv;type-material=type strain of Mycobacterium tuberculosis
+AL123456.3	EMBL	gene	1	1524	.	+	ID=gene-Rv0001;Name=dnaA;gbkey=Gene;gene=dnaA;gene_biotype=protein_coding;locus_tag=Rv0001
+AL123456.3	EMBL	CDS	1	1524	.	+	0	ID=cds-CCP42723.1;Parent=gene-Rv0001;Dbxref=EnsemblGenomes-Gn:Rv0001,EnsemblGenomes-Tr:CCP42723,GOA:P9WNW3,InterPro:IPR001957,InterPro:IPR003593,InterPro:IPR010921,InterPro:IPR013159,InterPro:IPR013317,InterPro:IPR018312,InterPro:IPR020591,InterPro:IPR027417,NCBI_GP:CCP42723.1;Name=CCP42723.1;Note=Rv0001%2C (MT0001%2C MTV029.01%2C P49993)%2C len: 507 aa. dnaA%2C chromosomal replication initiator protein (see citations below)%2C equivalent to other Mycobacterial chromosomal replication initiator proteins. Also highly similar to others except in N-terminus e.g. Q9ZH75|DNAA_STRCH chromosomal replication initiator protein from Streptomyces chrysomallus (624 aa). Contains PS00017 ATP/GTP-binding site motif A (P-loop) and PS01008 DnaA protein signature. Belongs to the DnaA family. Note that the first base of this gene has been taken as base 1 of the Mycobacterium tuberculosis H37Rv genomic sequence.;experiment=EXISTENCE: identified in proteomics study;gbkey=CDS;gene=dnaA;inference=protein motif:PROSITE:PS01008;locus_tag=Rv0001;product=Chromosomal replication initiator protein DnaA;protein_id=CCP42723.1;transl_table=11

--- a/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-negative-start.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-negative-start.gff
@@ -1,0 +1,10 @@
+##gff-version 3
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ASM19595v2
+#!genome-build-accession NCBI_Assembly:GCA_000195955.2
+##sequence-region AL123456.3 1 4411532
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=83332
+AL123456.3	EMBL	region	-1	4411532	.	+	.	ID=AL123456.3:1..4411532;Dbxref=taxon:83332;gbkey=Src;mol_type=genomic DNA;strain=H37Rv;type-material=type strain of Mycobacterium tuberculosis
+AL123456.3	EMBL	gene	1	1524	.	+	.	ID=gene-Rv0001;Name=dnaA;gbkey=Gene;gene=dnaA;gene_biotype=protein_coding;locus_tag=Rv0001
+AL123456.3	EMBL	CDS	1	1524	.	+	0	ID=cds-CCP42723.1;Parent=gene-Rv0001;Dbxref=EnsemblGenomes-Gn:Rv0001,EnsemblGenomes-Tr:CCP42723,GOA:P9WNW3,InterPro:IPR001957,InterPro:IPR003593,InterPro:IPR010921,InterPro:IPR013159,InterPro:IPR013317,InterPro:IPR018312,InterPro:IPR020591,InterPro:IPR027417,NCBI_GP:CCP42723.1;Name=CCP42723.1;Note=Rv0001%2C (MT0001%2C MTV029.01%2C P49993)%2C len: 507 aa. dnaA%2C chromosomal replication initiator protein (see citations below)%2C equivalent to other Mycobacterial chromosomal replication initiator proteins. Also highly similar to others except in N-terminus e.g. Q9ZH75|DNAA_STRCH chromosomal replication initiator protein from Streptomyces chrysomallus (624 aa). Contains PS00017 ATP/GTP-binding site motif A (P-loop) and PS01008 DnaA protein signature. Belongs to the DnaA family. Note that the first base of this gene has been taken as base 1 of the Mycobacterium tuberculosis H37Rv genomic sequence.;experiment=EXISTENCE: identified in proteomics study;gbkey=CDS;gene=dnaA;inference=protein motif:PROSITE:PS01008;locus_tag=Rv0001;product=Chromosomal replication initiator protein DnaA;protein_id=CCP42723.1;transl_table=11

--- a/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-no-version.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-no-version.gff
@@ -1,0 +1,9 @@
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ASM19595v2
+#!genome-build-accession NCBI_Assembly:GCA_000195955.2
+##sequence-region AL123456.3 1 4411532
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=83332
+AL123456.3	EMBL	region	1	4411532	.	+	.	ID=AL123456.3:1..4411532;Dbxref=taxon:83332;gbkey=Src;mol_type=genomic DNA;strain=H37Rv;type-material=type strain of Mycobacterium tuberculosis
+AL123456.3	EMBL	gene	1	1524	.	+	.	ID=gene-Rv0001;Name=dnaA;gbkey=Gene;gene=dnaA;gene_biotype=protein_coding;locus_tag=Rv0001
+AL123456.3	EMBL	CDS	1	1524	.	+	0	ID=cds-CCP42723.1;Parent=gene-Rv0001;Dbxref=EnsemblGenomes-Gn:Rv0001,EnsemblGenomes-Tr:CCP42723,GOA:P9WNW3,InterPro:IPR001957,InterPro:IPR003593,InterPro:IPR010921,InterPro:IPR013159,InterPro:IPR013317,InterPro:IPR018312,InterPro:IPR020591,InterPro:IPR027417,NCBI_GP:CCP42723.1;Name=CCP42723.1;Note=Rv0001%2C (MT0001%2C MTV029.01%2C P49993)%2C len: 507 aa. dnaA%2C chromosomal replication initiator protein (see citations below)%2C equivalent to other Mycobacterial chromosomal replication initiator proteins. Also highly similar to others except in N-terminus e.g. Q9ZH75|DNAA_STRCH chromosomal replication initiator protein from Streptomyces chrysomallus (624 aa). Contains PS00017 ATP/GTP-binding site motif A (P-loop) and PS01008 DnaA protein signature. Belongs to the DnaA family. Note that the first base of this gene has been taken as base 1 of the Mycobacterium tuberculosis H37Rv genomic sequence.;experiment=EXISTENCE: identified in proteomics study;gbkey=CDS;gene=dnaA;inference=protein motif:PROSITE:PS01008;locus_tag=Rv0001;product=Chromosomal replication initiator protein DnaA;protein_id=CCP42723.1;transl_table=11

--- a/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-wrong-version.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci-invalid/loci-wrong-version.gff
@@ -1,0 +1,10 @@
+##gff-version 2
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ASM19595v2
+#!genome-build-accession NCBI_Assembly:GCA_000195955.2
+##sequence-region AL123456.3 1 4411532
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=83332
+AL123456.3	EMBL	region	1	4411532	.	+	.	ID=AL123456.3:1..4411532;Dbxref=taxon:83332;gbkey=Src;mol_type=genomic DNA;strain=H37Rv;type-material=type strain of Mycobacterium tuberculosis
+AL123456.3	EMBL	gene	1	1524	.	+	.	ID=gene-Rv0001;Name=dnaA;gbkey=Gene;gene=dnaA;gene_biotype=protein_coding;locus_tag=Rv0001
+AL123456.3	EMBL	CDS	1	1524	.	+	0	ID=cds-CCP42723.1;Parent=gene-Rv0001;Dbxref=EnsemblGenomes-Gn:Rv0001,EnsemblGenomes-Tr:CCP42723,GOA:P9WNW3,InterPro:IPR001957,InterPro:IPR003593,InterPro:IPR010921,InterPro:IPR013159,InterPro:IPR013317,InterPro:IPR018312,InterPro:IPR020591,InterPro:IPR027417,NCBI_GP:CCP42723.1;Name=CCP42723.1;Note=Rv0001%2C (MT0001%2C MTV029.01%2C P49993)%2C len: 507 aa. dnaA%2C chromosomal replication initiator protein (see citations below)%2C equivalent to other Mycobacterial chromosomal replication initiator proteins. Also highly similar to others except in N-terminus e.g. Q9ZH75|DNAA_STRCH chromosomal replication initiator protein from Streptomyces chrysomallus (624 aa). Contains PS00017 ATP/GTP-binding site motif A (P-loop) and PS01008 DnaA protein signature. Belongs to the DnaA family. Note that the first base of this gene has been taken as base 1 of the Mycobacterium tuberculosis H37Rv genomic sequence.;experiment=EXISTENCE: identified in proteomics study;gbkey=CDS;gene=dnaA;inference=protein motif:PROSITE:PS01008;locus_tag=Rv0001;product=Chromosomal replication initiator protein DnaA;protein_id=CCP42723.1;transl_table=11

--- a/q2_types_genomics/genome_data/tests/data/loci/loci1.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci/loci1.gff
@@ -1,0 +1,10 @@
+##gff-version 3
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ASM19595v2
+#!genome-build-accession NCBI_Assembly:GCA_000195955.2
+##sequence-region AL123456.3 1 4411532
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=83332
+AL123456.3	EMBL	region	1	4411532	.	+	.	ID=AL123456.3:1..4411532;Dbxref=taxon:83332;gbkey=Src;mol_type=genomic DNA;strain=H37Rv;type-material=type strain of Mycobacterium tuberculosis
+AL123456.3	EMBL	gene	1	1524	.	+	.	ID=gene-Rv0001;Name=dnaA;gbkey=Gene;gene=dnaA;gene_biotype=protein_coding;locus_tag=Rv0001
+AL123456.3	EMBL	CDS	1	1524	.	+	0	ID=cds-CCP42723.1;Parent=gene-Rv0001;Dbxref=EnsemblGenomes-Gn:Rv0001,EnsemblGenomes-Tr:CCP42723,GOA:P9WNW3,InterPro:IPR001957,InterPro:IPR003593,InterPro:IPR010921,InterPro:IPR013159,InterPro:IPR013317,InterPro:IPR018312,InterPro:IPR020591,InterPro:IPR027417,NCBI_GP:CCP42723.1;Name=CCP42723.1;Note=Rv0001%2C (MT0001%2C MTV029.01%2C P49993)%2C len: 507 aa. dnaA%2C chromosomal replication initiator protein (see citations below)%2C equivalent to other Mycobacterial chromosomal replication initiator proteins. Also highly similar to others except in N-terminus e.g. Q9ZH75|DNAA_STRCH chromosomal replication initiator protein from Streptomyces chrysomallus (624 aa). Contains PS00017 ATP/GTP-binding site motif A (P-loop) and PS01008 DnaA protein signature. Belongs to the DnaA family. Note that the first base of this gene has been taken as base 1 of the Mycobacterium tuberculosis H37Rv genomic sequence.;experiment=EXISTENCE: identified in proteomics study;gbkey=CDS;gene=dnaA;inference=protein motif:PROSITE:PS01008;locus_tag=Rv0001;product=Chromosomal replication initiator protein DnaA;protein_id=CCP42723.1;transl_table=11

--- a/q2_types_genomics/genome_data/tests/data/loci/loci2.gff
+++ b/q2_types_genomics/genome_data/tests/data/loci/loci2.gff
@@ -1,0 +1,5 @@
+##gff-version 3
+# Sequence Data: seqnum=1;seqlen=1713046;seqhdr="k129_5480"
+# Model Data: version=Prodigal.v2.6.3;run_type=Metagenomic;model="49|_Nostoc_azollae__0708|B|38.5|11|1";gc_cont=38.40;transl_table=11;uses_sd=1
+k129_5480	Prodigal_v2.6.3	CDS	3	1988	255.7	-	0	ID=1_1;partial=10;start_type=ATG;rbs_motif=GGA/GAG/AGG;rbs_spacer=5-10bp;gc_cont=0.442;conf=99.99;score=255.03;cscore=250.12;sscore=4.92;rscore=0.92;uscore=0.44;tscore=4.21;
+k129_5480	Prodigal_v2.6.3	CDS	2150	2623	63.6	+	0	ID=1_2;partial=00;start_type=ATG;rbs_motif=GGA/GAG/AGG;rbs_spacer=5-10bp;gc_cont=0.426;conf=100.00;score=63.62;cscore=60.65;sscore=2.97;rscore=0.92;uscore=-2.15;tscore=4.21;

--- a/q2_types_genomics/genome_data/tests/test_format.py
+++ b/q2_types_genomics/genome_data/tests/test_format.py
@@ -8,10 +8,12 @@
 
 import unittest
 
+from qiime2.core.exceptions import ValidationError
 from qiime2.plugin.testing import TestPluginBase
 
 from .._format import (
-    GenesDirectoryFormat, ProteinsDirectoryFormat
+    GenesDirectoryFormat, ProteinsDirectoryFormat, GFF3Format,
+    LociDirectoryFormat
 )
 
 
@@ -20,15 +22,89 @@ class TestFormats(TestPluginBase):
 
     def test_genes_dirfmt_fa(self):
         dirpath = self.get_data_path('genes')
-        format = GenesDirectoryFormat(dirpath, mode='r')
+        fmt = GenesDirectoryFormat(dirpath, mode='r')
 
-        format.validate()
+        fmt.validate()
 
     def test_proteins_dirfmt_fa(self):
         dirpath = self.get_data_path('proteins')
-        format = ProteinsDirectoryFormat(dirpath, mode='r')
+        fmt = ProteinsDirectoryFormat(dirpath, mode='r')
 
-        format.validate()
+        fmt.validate()
+
+    def test_gff_format_positive(self):
+        filepath = self.get_data_path('loci/loci1.gff')
+        fmt = GFF3Format(filepath, mode='r')
+
+        fmt.validate()
+
+    def test_loci_dirfmt(self):
+        dirpath = self.get_data_path('loci')
+        fmt = LociDirectoryFormat(dirpath, mode='r')
+
+        fmt.validate()
+
+    def test_gff_format_wrong_version(self):
+        filepath = self.get_data_path('loci-invalid/loci-wrong-version.gff')
+        with self.assertRaisesRegex(
+                ValidationError, 'Invalid GFF format version: 2.'):
+            GFF3Format(filepath, mode='r').validate()
+
+    def test_gff_format_no_version(self):
+        filepath = self.get_data_path('loci-invalid/loci-no-version.gff')
+        with self.assertRaisesRegex(
+                ValidationError, '"gff-version" directive is missing'):
+            GFF3Format(filepath, mode='r').validate()
+
+    def test_gff_format_empty_directive(self):
+        filepath = self.get_data_path('loci-invalid/loci-directive-empty.gff')
+        with self.assertRaisesRegex(
+                ValidationError, 'directive entry on line 1 is incomplete.'):
+            GFF3Format(filepath, mode='r').validate()
+
+    def test_gff_format_lines_nonequal(self):
+        filepath = self.get_data_path('loci-invalid/loci-lines-unequal.gff')
+        with self.assertRaisesRegex(
+                ValidationError, 'line 9 has an incorrect number of elements'):
+            GFF3Format(filepath, mode='r').validate()
+
+    def test_gff_format_empty_feature(self):
+        filepath = self.get_data_path('loci-invalid/loci-empty-feature.gff')
+        with self.assertRaisesRegex(
+                ValidationError, r'empty feature found on line 9'):
+            GFF3Format(filepath, mode='r').validate()
+
+    def test_gff_format_invalid_char(self):
+        filepath = self.get_data_path('loci-invalid/loci-invalid-char.gff')
+        with self.assertRaisesRegex(
+                ValidationError, r'unescaped ">". The ID on line 10 '
+                                 r'was ">AL123456.3"'):
+            GFF3Format(filepath, mode='r').validate()
+
+    def test_gff_format_invalid_start_stop(self):
+        filepath = self.get_data_path('loci-invalid/loci-invalid-start.gff')
+        with self.assertRaisesRegex(
+                ValidationError, 'position on line 9 is bigger than stop'):
+            GFF3Format(filepath, mode='r').validate()
+
+    def test_gff_format_negative_position(self):
+        filepath = self.get_data_path('loci-invalid/loci-negative-start.gff')
+        with self.assertRaisesRegex(
+                ValidationError, 'positions on line 8 is incorrect'):
+            GFF3Format(filepath, mode='r').validate()
+
+    def test_gff_format_invalid_strand(self):
+        filepath = self.get_data_path('loci-invalid/loci-invalid-strand.gff')
+        with self.assertRaisesRegex(
+                ValidationError, 'feature on line 10 is not one '
+                                 'of the allowed'):
+            GFF3Format(filepath, mode='r').validate()
+
+    def test_gff_format_invalid_phase(self):
+        filepath = self.get_data_path('loci-invalid/loci-invalid-phase.gff')
+        with self.assertRaisesRegex(
+                ValidationError, 'The phase on line 10 was 8.'):
+            GFF3Format(filepath, mode='r').validate()
 
 
 if __name__ == '__main__':

--- a/q2_types_genomics/genome_data/tests/test_type.py
+++ b/q2_types_genomics/genome_data/tests/test_type.py
@@ -8,15 +8,16 @@
 
 import unittest
 
+from qiime2.plugin.testing import TestPluginBase
+
 from q2_types_genomics.genome_data import (
     GenomeData, Genes, Proteins, Loci,
     GenesDirectoryFormat, ProteinsDirectoryFormat, LociDirectoryFormat
 )
-from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTypes(TestPluginBase):
-    package = "q2_types_genomics.genome_data.tests"
+    package = 'q2_types_genomics.genome_data.tests'
 
     def test_genome_data_semantic_type_registration(self):
         self.assertRegisteredSemanticType(GenomeData)

--- a/q2_types_genomics/genome_data/tests/test_type.py
+++ b/q2_types_genomics/genome_data/tests/test_type.py
@@ -9,7 +9,8 @@
 import unittest
 
 from q2_types_genomics.genome_data import (
-    GenomeData, Genes, Proteins, GenesDirectoryFormat, ProteinsDirectoryFormat
+    GenomeData, Genes, Proteins, Loci,
+    GenesDirectoryFormat, ProteinsDirectoryFormat, LociDirectoryFormat
 )
 from qiime2.plugin.testing import TestPluginBase
 
@@ -26,6 +27,9 @@ class TestTypes(TestPluginBase):
     def test_proteins_semantic_type_registration(self):
         self.assertRegisteredSemanticType(Proteins)
 
+    def test_loci_semantic_type_registration(self):
+        self.assertRegisteredSemanticType(Loci)
+
     def test_genome_data_genes_to_genes_dir_fmt_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
             GenomeData[Genes], GenesDirectoryFormat)
@@ -33,6 +37,10 @@ class TestTypes(TestPluginBase):
     def test_genome_data_proteins_to_proteins_dir_fmt_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
             GenomeData[Proteins], ProteinsDirectoryFormat)
+
+    def test_genome_data_loci_to_loci_dir_fmt_registration(self):
+        self.assertSemanticTypeRegisteredToFormat(
+            GenomeData[Loci], LociDirectoryFormat)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- adds a new GenomeData type: `GenomeData[Loci]` to work with per-genome GFF files containing information about features found in respective genomes
- adds new `GFF3Format` format introducing validation of GFF3 files
- adds tests, where appropriate

_Note to self: clean up and merge after #22._ 

Closes #5.