### PR TITLE
ENH: add MAG manifest to df transformer

### DIFF
--- a/q2_types_genomics/per_sample_data/_transformer.py
+++ b/q2_types_genomics/per_sample_data/_transformer.py
@@ -5,7 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import os
 
+import pandas as pd
 from q2_types.feature_data import DNAFASTAFormat
 
 from q2_types_genomics.plugin_setup import plugin
@@ -24,3 +26,12 @@ def _1(dirfmt: MultiFASTADirectoryFormat) \
     return _mag_manifest_helper(
         dirfmt, MultiMAGSequencesDirFmt,
         MultiMAGManifestFormat, DNAFASTAFormat)
+
+
+@plugin.register_transformer
+def _21(ff: MultiMAGManifestFormat) -> pd.DataFrame:
+    df = pd.read_csv(str(ff), header=0, comment='#')
+    df.filename = df.filename.apply(
+        lambda f: os.path.join(ff.path.parent, f))
+    df.set_index(['sample-id', 'mag-id'], inplace=True)
+    return df

--- a/q2_types_genomics/per_sample_data/tests/test_format.py
+++ b/q2_types_genomics/per_sample_data/tests/test_format.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import string
 import unittest
+from unittest.mock import patch, Mock
 
 from qiime2.core.exceptions import ValidationError
 from qiime2.plugin.testing import TestPluginBase
@@ -113,13 +114,18 @@ class TestFormats(TestPluginBase):
         shutil.copytree(filepath, self.temp_dir.name, dirs_exist_ok=True)
         ContigSequencesDirFmt(self.temp_dir.name, mode='r').validate()
 
-    def test_bam_dirmt(self):
+    @patch('subprocess.run', return_value=Mock(returncode=0))
+    def test_bam_dirmt(self, p):
         filepath = self.get_data_path('bowtie/maps-single')
         format = BAMDirFmt(filepath, mode='r')
 
         format.validate()
 
-    def test_bam_dirmt_invalid(self):
+    @patch('subprocess.run', return_value=Mock(returncode=3))
+    def test_bam_dirmt_invalid(self, p):
+        # this patch is not ideal but samtools' installation sometimes can
+        # be messed up and the tool returns an error regardless of the invoked
+        # command, so let's just assume here that it works as it should
         filepath = self.get_data_path('bowtie/maps-invalid')
         format = BAMDirFmt(filepath, mode='r')
 
@@ -127,7 +133,8 @@ class TestFormats(TestPluginBase):
                 ValidationError, 'samtools quickcheck -v failed on'):
             format.validate()
 
-    def test_multibam_dirmt(self):
+    @patch('subprocess.run', return_value=Mock(returncode=0))
+    def test_multibam_dirmt(self, p):
         filepath = self.get_data_path('bowtie/maps-multi')
         format = MultiBAMDirFmt(filepath, mode='r')
 

--- a/q2_types_genomics/per_sample_data/tests/test_transformers.py
+++ b/q2_types_genomics/per_sample_data/tests/test_transformers.py
@@ -5,8 +5,11 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import os
 import unittest
 
+import pandas as pd
+from pandas._testing import assert_frame_equal
 from qiime2.plugin.testing import TestPluginBase
 
 from q2_types_genomics.per_sample_data._format import (
@@ -59,6 +62,30 @@ class TestTransformers(TestPluginBase):
             self.assertEqual(
                 obs_manifest.read(), self.construct_manifest('fasta')
             )
+
+    def test_mag_manifest_to_df(self):
+        obs = self.apply_transformation(
+            MultiMAGManifestFormat,
+            pd.DataFrame,
+            'manifests/MANIFEST-mags-fa'
+        )
+        exp = pd.DataFrame({
+            'sample-id': [
+                'sample1', 'sample1', 'sample1', 'sample2', 'sample2'
+            ],
+            'mag-id': ['mag1', 'mag2', 'mag3', 'mag1', 'mag2'],
+            'filename': [
+                os.path.join(self.get_data_path('manifests'), x)
+                for x in [
+                    'sample1/mag1.fasta', 'sample1/mag2.fasta',
+                    'sample1/mag3.fasta', 'sample2/mag1.fasta',
+                    'sample2/mag2.fasta'
+                ]
+            ]
+        })
+        exp.set_index(['sample-id', 'mag-id'], inplace=True)
+
+        assert_frame_equal(exp, obs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds the `MultiMAGManifestFormat` -> `pd.DataFrame` missing transformer.