### PR TITLE
ENH: add FeatureData types for Kraken 2 outputs

### DIFF
--- a/q2_types_genomics/kraken2/_format.py
+++ b/q2_types_genomics/kraken2/_format.py
@@ -11,7 +11,6 @@ from pandas.core.dtypes.common import is_string_dtype
 from qiime2.core.exceptions import ValidationError
 from qiime2.plugin import model
 
-from ..per_sample_data._format import MultiDirValidationMixin
 from ..plugin_setup import plugin
 
 
@@ -71,8 +70,7 @@ class Kraken2ReportFormat(model.TextFileFormat):
             )
 
 
-class Kraken2ReportDirectoryFormat(MultiDirValidationMixin,
-                                   model.DirectoryFormat):
+class Kraken2ReportDirectoryFormat(model.DirectoryFormat):
     reports = model.FileCollection(
         r'.+report\.(txt|tsv)$', format=Kraken2ReportFormat
     )
@@ -100,8 +98,7 @@ class Kraken2OutputFormat(model.TextFileFormat):
             )
 
 
-class Kraken2OutputDirectoryFormat(MultiDirValidationMixin,
-                                   model.DirectoryFormat):
+class Kraken2OutputDirectoryFormat(model.DirectoryFormat):
     reports = model.FileCollection(
         r'.+output\.(txt|tsv)$', format=Kraken2OutputFormat
     )

--- a/q2_types_genomics/kraken2/_type.py
+++ b/q2_types_genomics/kraken2/_type.py
@@ -5,6 +5,7 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+from q2_types.feature_data import FeatureData
 from q2_types.sample_data import SampleData
 from qiime2.plugin import SemanticType
 
@@ -16,10 +17,12 @@ from ..plugin_setup import plugin
 
 
 Kraken2Reports = SemanticType(
-    'Kraken2Report', variant_of=SampleData.field['type']
+    'Kraken2Report',
+    variant_of=[SampleData.field['type'], FeatureData.field['type']]
 )
 Kraken2Outputs = SemanticType(
-    'Kraken2Output', variant_of=SampleData.field['type']
+    'Kraken2Output',
+    variant_of=[SampleData.field['type'], FeatureData.field['type']]
 )
 Kraken2DB = SemanticType('Kraken2DB')
 BrackenDB = SemanticType('BrackenDB')
@@ -33,7 +36,15 @@ plugin.register_semantic_type_to_format(
     artifact_format=Kraken2ReportDirectoryFormat
 )
 plugin.register_semantic_type_to_format(
+    FeatureData[Kraken2Reports],
+    artifact_format=Kraken2ReportDirectoryFormat
+)
+plugin.register_semantic_type_to_format(
     SampleData[Kraken2Outputs],
+    artifact_format=Kraken2OutputDirectoryFormat
+)
+plugin.register_semantic_type_to_format(
+    FeatureData[Kraken2Outputs],
     artifact_format=Kraken2OutputDirectoryFormat
 )
 plugin.register_semantic_type_to_format(

--- a/q2_types_genomics/kraken2/tests/test_type.py
+++ b/q2_types_genomics/kraken2/tests/test_type.py
@@ -8,6 +8,7 @@
 
 import unittest
 
+from q2_types.feature_data import FeatureData
 from q2_types.sample_data import SampleData
 from qiime2.plugin.testing import TestPluginBase
 
@@ -26,18 +27,30 @@ class TestTypes(TestPluginBase):
     def test_reports_semantic_type_registration(self):
         self.assertRegisteredSemanticType(Kraken2Reports)
 
-    def test_reports_semantic_type_to_format_registration(self):
+    def test_reports_semantic_type_to_format_registration_sd(self):
         self.assertSemanticTypeRegisteredToFormat(
             SampleData[Kraken2Reports],
+            Kraken2ReportDirectoryFormat
+        )
+
+    def test_reports_semantic_type_to_format_registration_fd(self):
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureData[Kraken2Reports],
             Kraken2ReportDirectoryFormat
         )
 
     def test_outputs_semantic_type_registration(self):
         self.assertRegisteredSemanticType(Kraken2Outputs)
 
-    def test_outputs_semantic_type_to_format_registration(self):
+    def test_outputs_semantic_type_to_format_registration_sd(self):
         self.assertSemanticTypeRegisteredToFormat(
             SampleData[Kraken2Outputs],
+            Kraken2OutputDirectoryFormat
+        )
+
+    def test_outputs_semantic_type_to_format_registration_fd(self):
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureData[Kraken2Outputs],
             Kraken2OutputDirectoryFormat
         )
 


### PR DESCRIPTION
This PR adds the `FeatureData[MAG]` semantic type required to store dereplicated MAGs.