### PR TITLE
ENH: Update `NCBITaxonomyDirFmt` to accomodate data-version file

### DIFF
--- a/q2_types_genomics/reference_db/__init__.py
+++ b/q2_types_genomics/reference_db/__init__.py
@@ -19,10 +19,13 @@ from q2_types_genomics.reference_db._format import (
     DiamondDatabaseFileFmt,
     DiamondDatabaseDirFmt,
     NCBITaxonomyDirFmt,
+    NCBITaxonomyVersionFormat,
     EggnogProteinSequencesDirFmt
     )
 
 __all__ = ['ReferenceDB', 'Diamond', 'Eggnog', 'DiamondDatabaseFileFmt',
            'DiamondDatabaseDirFmt', 'EggnogRefDirFmt', 'EggnogRefTextFileFmt',
            'EggnogRefBinFileFmt', 'NCBITaxonomyDirFmt', 'NCBITaxonomy',
-           'EggnogProteinSequencesDirFmt', 'EggnogProteinSequences']
+           'EggnogProteinSequencesDirFmt', 'EggnogProteinSequences',
+           'NCBITaxonomyVersionFormat'
+           ]

--- a/q2_types_genomics/reference_db/_format.py
+++ b/q2_types_genomics/reference_db/_format.py
@@ -343,7 +343,7 @@ class NCBITaxonomyVersionFormat(model.TextFileFormat):
 
 
 plugin.register_formats(
-    NCBITaxonomyNodesFormat, NCBITaxonomyNamesFormat, 
+    NCBITaxonomyNodesFormat, NCBITaxonomyNamesFormat,
     NCBITaxonomyBinaryFileFmt, NCBITaxonomyVersionFormat
     )
 

--- a/q2_types_genomics/reference_db/tests/data/ncbi/db-valid/version.tsv
+++ b/q2_types_genomics/reference_db/tests/data/ncbi/db-valid/version.tsv
@@ -1,0 +1,4 @@
+file_name	date	time
+names.dmp	01/12/2023	  10:28:10
+nodes.dmp	01/12/2023	  10:27:36
+prot.accession2taxid.gz	05/12/2023	10:33:51

--- a/q2_types_genomics/reference_db/tests/data/ncbi/version.tsv
+++ b/q2_types_genomics/reference_db/tests/data/ncbi/version.tsv
@@ -1,0 +1,4 @@
+file_name	date	time
+names.dmp	01/12/2023	10:28:10
+nodes.dmp	01/12/2023	10:27:36
+prot.accession2taxid.gz	05/12/2023	10:33:51

--- a/q2_types_genomics/reference_db/tests/data/ncbi/version_invalid_date.tsv
+++ b/q2_types_genomics/reference_db/tests/data/ncbi/version_invalid_date.tsv
@@ -1,0 +1,4 @@
+file_name	date	time
+names.dmp	01/13/2023	10:28:10
+nodes.dmp	01/12/2023	10:27:36
+prot.accession2taxid.gz	05/12/2023	10:33:51

--- a/q2_types_genomics/reference_db/tests/data/ncbi/version_invalid_filename.tsv
+++ b/q2_types_genomics/reference_db/tests/data/ncbi/version_invalid_filename.tsv
@@ -1,0 +1,4 @@
+file_name	date	time
+names.dmp	01/12/2023	10:28:10
+nodes.dmp	01/12/2023	10:27:36
+something_else	05/12/2023	10:33:51

--- a/q2_types_genomics/reference_db/tests/data/ncbi/version_invalid_time.tsv
+++ b/q2_types_genomics/reference_db/tests/data/ncbi/version_invalid_time.tsv
@@ -1,0 +1,4 @@
+file_name	date	time
+names.dmp	01/12/2023	10:28:10
+nodes.dmp	01/12/2023	10:27:36
+prot.accession2taxid.gz	05/12/2023	25:33:51

--- a/q2_types_genomics/reference_db/tests/data/ncbi/version_repeated_filename.tsv
+++ b/q2_types_genomics/reference_db/tests/data/ncbi/version_repeated_filename.tsv
@@ -1,0 +1,4 @@
+file_name	date	time
+names.dmp	01/12/2023	10:28:10
+nodes.dmp	01/12/2023	10:27:36
+nodes.dmp	05/12/2023	10:33:51

--- a/q2_types_genomics/reference_db/tests/data/ncbi/version_too_many_cols.tsv
+++ b/q2_types_genomics/reference_db/tests/data/ncbi/version_too_many_cols.tsv
@@ -1,0 +1,4 @@
+file_name	date	time	something else
+names.dmp	01/12/2023	10:28:10
+nodes.dmp	01/12/2023	10:27:36
+prot.accession2taxid.gz	05/12/2023	10:33:51

--- a/q2_types_genomics/reference_db/tests/data/ncbi/version_too_many_entries.tsv
+++ b/q2_types_genomics/reference_db/tests/data/ncbi/version_too_many_entries.tsv
@@ -1,0 +1,5 @@
+file_name	date	time
+names.dmp	01/12/2023	10:28:10
+nodes.dmp	01/12/2023	10:27:36
+prot.accession2taxid.gz	05/12/2023	10:33:51
+prot.accession2taxid.gz	05/12/2023	10:33:51

--- a/q2_types_genomics/reference_db/tests/data/ncbi/version_wrong_cols.tsv
+++ b/q2_types_genomics/reference_db/tests/data/ncbi/version_wrong_cols.tsv
@@ -1,0 +1,4 @@
+file_name	date	something else
+names.dmp	01/12/2023	10:28:10
+nodes.dmp	01/12/2023	10:27:36
+prot.accession2taxid.gz	05/12/2023	10:33:51

--- a/q2_types_genomics/reference_db/tests/test_format.py
+++ b/q2_types_genomics/reference_db/tests/test_format.py
@@ -10,7 +10,8 @@ from q2_types_genomics.reference_db._format import (
         DiamondDatabaseFileFmt, DiamondDatabaseDirFmt, EggnogRefBinFileFmt,
         EggnogRefDirFmt, NCBITaxonomyNamesFormat, NCBITaxonomyNodesFormat,
         NCBITaxonomyDirFmt, NCBITaxonomyBinaryFileFmt,
-        EggnogProteinSequencesDirFmt, EggnogRefTextFileFmt
+        EggnogProteinSequencesDirFmt, EggnogRefTextFileFmt,
+        NCBITaxonomyVersionFormat
         )
 from qiime2.plugin import ValidationError
 
@@ -264,5 +265,73 @@ class TestNCBIFormats(TestPluginBase):
         with self.assertRaisesRegex(
                 ValidationError,
                 r"['A0A009IHW8', 'A0A009IHW8.1', '1310613', '1835922267s']"
+        ):
+            format.validate()
+
+    def test_version_file_fmt_positive(self):
+        dirpath = self.get_data_path("ncbi/db-valid/version.tsv")
+        format = NCBITaxonomyVersionFormat(dirpath, mode="r")
+        format.validate()
+
+    def test_version_file_fmt_too_many_cols(self):
+        dirpath = self.get_data_path("ncbi/version_too_many_cols.tsv")
+        format = NCBITaxonomyVersionFormat(dirpath, mode="r")
+        with self.assertRaisesRegex(
+                ValidationError,
+                "Too many columns"
+        ):
+            format.validate()
+
+    def test_version_file_fmt_wrong_cols(self):
+        dirpath = self.get_data_path("ncbi/version_wrong_cols.tsv")
+        format = NCBITaxonomyVersionFormat(dirpath, mode="r")
+        with self.assertRaisesRegex(
+                ValidationError,
+                "Wrong columns"
+        ):
+            format.validate()
+
+    def test_version_file_fmt_too_many_entries(self):
+        dirpath = self.get_data_path("ncbi/version_too_many_entries.tsv")
+        format = NCBITaxonomyVersionFormat(dirpath, mode="r")
+        with self.assertRaisesRegex(
+                ValidationError,
+                "Too many entries"
+        ):
+            format.validate()
+
+    def test_version_file_fmt_invalid_filename(self):
+        dirpath = self.get_data_path("ncbi/version_invalid_filename.tsv")
+        format = NCBITaxonomyVersionFormat(dirpath, mode="r")
+        with self.assertRaisesRegex(
+                ValidationError,
+                "Invalid or repeated filename"
+        ):
+            format.validate()
+
+    def test_version_file_fmt_repeated_filename(self):
+        dirpath = self.get_data_path("ncbi/version_repeated_filename.tsv")
+        format = NCBITaxonomyVersionFormat(dirpath, mode="r")
+        with self.assertRaisesRegex(
+                ValidationError,
+                "Invalid or repeated filename"
+        ):
+            format.validate()
+
+    def test_version_file_fmt_invalid_date(self):
+        dirpath = self.get_data_path("ncbi/version_invalid_date.tsv")
+        format = NCBITaxonomyVersionFormat(dirpath, mode="r")
+        with self.assertRaisesRegex(
+                ValidationError,
+                "Invalid date"
+        ):
+            format.validate()
+
+    def test_version_file_fmt_invalid_time(self):
+        dirpath = self.get_data_path("ncbi/version_invalid_time.tsv")
+        format = NCBITaxonomyVersionFormat(dirpath, mode="r")
+        with self.assertRaisesRegex(
+                ValidationError,
+                "Invalid time"
         ):
             format.validate()


### PR DESCRIPTION
### About this repo
- `q2-types-genomics` is a `qiime2` plugin that defines semantic types for other plugins.
- The current PR updates an already existing directory format by adding a new file, adding the corresponding file format for the new file, as well as validation, and tests for it. 

### What's new
- Closes #72 
- `NCBITaxonomyDirFmt` now contains 4 files instead of 3.
   - `nodes.dmp`
   - `names.dmp`
   - `prot.accession2taxid.gz`
   - new -> `version.tsv`
- Why is this useful? There is a need to add information about the version of the first three files since it might impact downstream results. By adding a `version.tsv` file this information is effectively recorded in the provenance of downstream artifacts. 

### Set up an environment
```bash
# For linux: 
# export MY_OS="linux"
# For mac:
export MY_OS="osx" 
wget "https://data.qiime2.org/distro/shotgun/qiime2-shotgun-2023.9-py38-"$MY_OS"-conda.yml"
conda env create -n q2-shotgun --file qiime2-shotgun-2023.9-py38-osx-conda.yml
rm "qiime2-shotgun-2023.9-py38-"$MY_OS"-conda.yml"
```

### Run it locally 
1. First, clone the repo and checkout the PR branch:
```bash
# Remove q2-types-genomics so you can install your local version.
conda activate q2-shotgun
conda remove q2-types-genomics q2-types
pip install git+https://github.com/qiime2/q2-types.git
git clone git@github.com:bokulich-lab/q2-types-genomics.git
cd q2-types-genomics
gh pr checkout 73
pip install -e .
```

2. Let's get you some data to play with: 
```bash
cd wherever_you_want_to_download_the_data_to
```

> The next commands will download ~15 Gb of data
```bash
# Download *.dmp
wget ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdmp.zip
unzip -j taxdmp.zip names.dmp nodes.dmp -d ncbi_tax_data
rm taxdmp.zip

# Download prot.accession2taxid.gz
wget ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/prot.accession2taxid.gz -P ncbi_tax_data

# Make the version.tsv file
echo -e "file_name\tdate\ttime" > ncbi_tax_data/version.tsv
ls -l -D "%d/%m/%Y %H:%M:%S" ncbi_tax_data | awk '{print $8, $6, $7}' | grep -E '(nodes\.dmp|names\.dmp|prot\.accession2taxid\.gz)' | tr ' ' '\t' >> ncbi_tax_data/version.tsv
```

3. Test it out!
```bash
qiime tools import --input-path ncbi_tax_data --output-path ncbi_tax_data.qza --type "ReferenceDB[NCBITaxonomy]"
```

### Running the tests
```bash
pytest -W ignore -vv --pyargs q2_types_genomics
```